### PR TITLE
Manage log batches in a linked list queue

### DIFF
--- a/pg_otel.c
+++ b/pg_otel.c
@@ -100,7 +100,7 @@ otel_SharedMemoryRequestHook(void)
 		prev_SharedMemoryRequestHook();
 #endif
 
-	RequestNamedLWLockTranche(PG_OTEL_LIBRARY, PG_OTEL_LWLOCKS);
+	/* no-op */
 }
 
 /*
@@ -120,8 +120,7 @@ otel_WorkerMain(Datum arg)
 	worker.pid = MyProcPid;
 
 	otel_CloseWrite(&worker.ipc);
-	otel_WorkerRun(&worker, &config,
-				   GetNamedLWLockTranche(PG_OTEL_LIBRARY));
+	otel_WorkerRun(&worker, &config);
 
 	/* Exit zero so we aren't restarted */
 	proc_exit(0);

--- a/pg_otel.h
+++ b/pg_otel.h
@@ -6,6 +6,8 @@
 #define PG_OTEL_LIBRARY "pg_otel"
 #define PG_OTEL_VERSION "0.0.1"
 
+#define PG_OTEL_HEADER_PROTOBUF "Content-Type: application/x-protobuf"
+#define PG_OTEL_SCHEMA "https://opentelemetry.io/schemas/1.9.0"
 #define PG_OTEL_USERAGENT PG_OTEL_LIBRARY "/" PG_OTEL_VERSION
 
 #endif

--- a/pg_otel_ipc.h
+++ b/pg_otel_ipc.h
@@ -15,9 +15,10 @@
 
 struct otelIPC
 {
-	List *buckets[3][256];
-	char  buffer[2 * PIPE_CHUNK_SIZE];
-	int   offset;
+	List    *buckets[3][256];
+	uint8_t  buffer[2 * PIPE_CHUNK_SIZE];
+	int      offset, unfinished;
+	bool     eof;
 
 #ifndef WIN32
 	int pipe[2];
@@ -32,7 +33,7 @@ static void
 otel_ReceiveOverIPC(struct otelIPC *ipc,
 					void *opaque,
 					void (*dispatch)(void *opaque, bits8 signal,
-									 const char *message, size_t size));
+									 const uint8_t *message, size_t size));
 
 static void
 otel_SendOverIPC(struct otelIPC *ipc,

--- a/pg_otel_logs.c
+++ b/pg_otel_logs.c
@@ -21,6 +21,9 @@
 #include "pg_otel_ipc.h"
 #include "pg_otel_logs.h"
 
+static struct otelLogsBatch *otel_AddLogsBatch(struct otelLogsExporter *);
+static void otel_AddLogsResource(struct otelLogsBatch *, struct otelResource *);
+
 /*
  * Called by backends to send one log message to the background worker.
  */
@@ -207,85 +210,147 @@ otel_SendLogMessage(struct otelIPC *ipc, const ErrorData *edata)
 }
 
 /*
- * Called by the background worker to put a log message in the exporter batch.
+ * Called by the background worker to put a log message in the exporter queue.
  */
 static void
-otel_ReceiveLogMessage(struct otelLogsThread *t, const char *packed, size_t size)
+otel_ReceiveLogMessage(struct otelLogsExporter *exporter,
+					   const uint8_t *packed, size_t size)
 {
-	LWLockAcquire(t->lock, LW_EXCLUSIVE);
+	struct otelLogsBatch *batch;
+	OTEL_TYPE_LOGS(LogRecord) *record;
+	OTEL_TYPE_LOGS(ResourceLogs) *resourceLogs;
 
-	if (t->batchHold.length < t->batchHold.capacity)
+	if (dlist_is_empty(&exporter->queue))
+		batch = otel_AddLogsBatch(exporter);
+	else
+		batch = dlist_tail_element(struct otelLogsBatch, list_node,
+								   &exporter->queue);
+
+	if (exporter->queueLength >= exporter->queueMax)
+		batch->dropped++;
+	else
 	{
 		/* unpack returns NULL when it cannot unpack the message */
-		OTEL_TYPE_LOGS(LogRecord) *record = OTEL_FUNC_LOGS(log_record__unpack)
-			(&t->batchHold.allocator, size, (const uint8_t *)packed);
+		record = OTEL_FUNC_LOGS(log_record__unpack)
+			(&batch->allocator, size, packed);
 
-		if (record != NULL)
-		{
-			t->batchHold.records[t->batchHold.length] = record;
-			t->batchHold.length++;
-		}
+		if (record == NULL)
+			batch->dropped++;
 		else
-			t->batchHold.dropped++;
-	}
-	else
-		t->batchHold.dropped++;
+		{
+			if (batch->length >= batch->capacity)
+				batch = otel_AddLogsBatch(exporter);
 
-	LWLockRelease(t->lock);
+			batch->records[batch->length] = record;
+			batch->length++;
+			exporter->queueLength++;
+
+			resourceLogs = llast(batch->resourceLogs);
+			resourceLogs->scope_logs[0]->n_log_records++;
+		}
+	}
 }
 
-static void
-otel_InitLogsBatch(struct otelLogsBatch *batch, int capacity)
+/*
+ * Allocate a batch in its own top-level context and append it to exporter's queue.
+ */
+static struct otelLogsBatch *
+otel_AddLogsBatch(struct otelLogsExporter *exporter)
 {
-	Assert(batch != NULL);
+	MemoryContext ctx = AllocSetContextCreate(NULL, /* parent */
+											  PG_OTEL_LIBRARY " logs batch",
+											  ALLOCSET_START_SMALL_SIZES);
+	struct otelLogsBatch *batch = MemoryContextAllocZero(ctx, sizeof(*batch));
 
-	batch->capacity = capacity;
-	batch->dropped = 0;
-	batch->length = 0;
-	batch->records = palloc0(sizeof(*(batch->records)) * capacity);
-	batch->context = AllocSetContextCreate(NULL, /* parent */
-										   PG_OTEL_LIBRARY " logs batch",
-										   ALLOCSET_START_SMALL_SIZES);
+	batch->capacity = exporter->batchMax;
+	batch->context = ctx;
+	batch->records = MemoryContextAlloc(batch->context,
+										sizeof(*(batch->records)) *
+										batch->capacity);
 
 	otel_InitProtobufCAllocator(&batch->allocator, batch->context);
+	otel_AddLogsResource(batch, &exporter->resource);
+
+	dlist_push_tail(&exporter->queue, &batch->list_node);
+
+	return batch;
 }
 
 /*
- * Called by the exporter thread after a batch has been sent to the collector.
+ * Store a copy of resource in batch to be exported with any following records.
  */
 static void
-otel_ResetLogsBatch(struct otelLogsBatch *batch)
+otel_AddLogsResource(struct otelLogsBatch *batch, struct otelResource *resource)
 {
-	Assert(batch != NULL);
+	MemoryContext oldContext = MemoryContextSwitchTo(batch->context);
+	OTEL_TYPE_LOGS(ResourceLogs)  data;
+	OTEL_TYPE_LOGS(ResourceLogs) *next;
+	OTEL_TYPE_LOGS(ScopeLogs)     scopeLogsData;
+	OTEL_TYPE_LOGS(ScopeLogs)    *scopeLogsList[1] = { &scopeLogsData };
+	uint8_t *packed;
+	size_t size;
 
-	batch->dropped = 0;
-	batch->length = 0;
-	MemoryContextReset(batch->context);
+	/* Prepare a ResourceLogs object containing a list of one ScopeLogs */
+	OTEL_FUNC_LOGS(resource_logs__init)(&data);
+	OTEL_FUNC_LOGS(scope_logs__init)(&scopeLogsData);
+	data.resource = &resource->resource;
+	data.scope_logs = scopeLogsList;
+	data.n_scope_logs = 1;
+
+	/* Copy it into the MemoryContext of the batch */
+	packed = palloc(OTEL_FUNC_LOGS(resource_logs__get_packed_size)(&data));
+	size = OTEL_FUNC_LOGS(resource_logs__pack)(&data, packed);
+	next = OTEL_FUNC_LOGS(resource_logs__unpack)(&batch->allocator, size, packed);
+	pfree(packed);
+
+	/* Point that copy at the current position in the list of LogRecords */
+	next->scope_logs[0]->log_records = batch->records + batch->length;
+	next->scope_logs[0]->n_log_records = 0;
+
+	batch->resourceLogs = lappend(batch->resourceLogs, next);
+
+	MemoryContextSwitchTo(oldContext);
 }
 
 /*
- * Called by the exporter thread to send a batch to the collector.
+ * Send request to the collector configured in exporter, ignoring any errors.
  */
 static void
-otel_SendLogsToCollector(struct otelLogsThread *t,
-						 const OTEL_TYPE_EXPORT_LOGS(Request) *request)
+otel_SendLogsRequestToCollector(MemoryContext ctx, CURL *http,
+								struct otelLogsExporter *exporter,
+								OTEL_TYPE_EXPORT_LOGS(Request) *request)
 {
+	uint8_t *body = NULL;
 	char     httpErrorBuffer[CURL_ERROR_SIZE];
 	CURLcode result;
+	size_t   size;
 
 	struct curl_slist *headers = NULL;
-	uint8_t           *body;
-	size_t             size;
+
+	size = OTEL_FUNC_EXPORT_LOGS(request__get_packed_size)(request);
+	body = MemoryContextAlloc(ctx, size);
+	size = OTEL_FUNC_EXPORT_LOGS(request__pack)(request, body);
 
 	/* These do not error or their error can be ignored */
-	curl_easy_reset(t->http);
-	curl_easy_setopt(t->http, CURLOPT_ERRORBUFFER, httpErrorBuffer);
-	curl_easy_setopt(t->http, CURLOPT_USERAGENT, PG_OTEL_USERAGENT);
+	curl_easy_reset(http);
+	curl_easy_setopt(http, CURLOPT_ERRORBUFFER, httpErrorBuffer);
+	curl_easy_setopt(http, CURLOPT_CONNECTTIMEOUT_MS, 1 + (exporter->timeoutMS / 2));
+	curl_easy_setopt(http, CURLOPT_TIMEOUT_MS, exporter->timeoutMS);
+	curl_easy_setopt(http, CURLOPT_USERAGENT, PG_OTEL_USERAGENT);
+
+	if (exporter->insecure)
+	{
+		curl_easy_setopt(http, CURLOPT_SSL_VERIFYHOST, 0);
+		curl_easy_setopt(http, CURLOPT_SSL_VERIFYPEER, 0);
+	}
 
 	/* TODO: check errors */
-	headers = curl_slist_append(headers, "Content-Type: application/x-protobuf");
+	result = curl_easy_setopt(http, CURLOPT_URL, exporter->endpoint);
 
-	curl_easy_setopt(t->http, CURLOPT_HTTPHEADER, headers);
+	/* TODO: check errors */
+	headers = curl_slist_append(headers, PG_OTEL_HEADER_PROTOBUF);
+
+	curl_easy_setopt(http, CURLOPT_HTTPHEADER, headers);
 
 	/*
 	 * TODO: gzip encoding
@@ -296,154 +361,97 @@ otel_SendLogsToCollector(struct otelLogsThread *t,
 
 #ifdef PG_OTEL_DEBUG
 	/* Print debugging information to stderr; off by default */
-	curl_easy_setopt(t->http, CURLOPT_VERBOSE, 1);
+	curl_easy_setopt(http, CURLOPT_VERBOSE, 1);
 #endif
 
-	/* Read configuration and build the request body while holding the lock */
-	{
-		LWLockAcquire(t->lock, LW_EXCLUSIVE);
+	curl_easy_setopt(http, CURLOPT_POST, 1);
+	curl_easy_setopt(http, CURLOPT_POSTFIELDS, body);
+	curl_easy_setopt(http, CURLOPT_POSTFIELDSIZE, size);
 
-		body = MemoryContextAlloc
-			(t->batchSend.context, OTEL_FUNC_EXPORT_LOGS(request__get_packed_size)(request));
-		size = OTEL_FUNC_EXPORT_LOGS(request__pack)(request, body);
-
-		result = curl_easy_setopt(t->http, CURLOPT_URL, t->endpoint);
-
-		/* These do not error or their error can be ignored */
-		curl_easy_setopt(t->http, CURLOPT_CONNECTTIMEOUT_MS, 1 + (t->timeoutMS / 2));
-		curl_easy_setopt(t->http, CURLOPT_TIMEOUT_MS, t->timeoutMS);
-
-		if (t->insecure)
-		{
-			curl_easy_setopt(t->http, CURLOPT_SSL_VERIFYHOST, 0);
-			curl_easy_setopt(t->http, CURLOPT_SSL_VERIFYPEER, 0);
-		}
-
-		LWLockRelease(t->lock);
-	}
-
-	curl_easy_setopt(t->http, CURLOPT_POST, 1);
-	curl_easy_setopt(t->http, CURLOPT_POSTFIELDS, body);
-	curl_easy_setopt(t->http, CURLOPT_POSTFIELDSIZE, size);
-
-	result = curl_easy_perform(t->http);
+	result = curl_easy_perform(http);
 
 	/* TODO: check errors */
 	result = result;
 
 	curl_slist_free_all(headers);
+	curl_easy_reset(http);
 	pfree(body);
 }
 
 /*
- * Exporter thread entry point. See [otel_StartLogsThread].
+ * Called by the background worker to send a batch to the collector.
  */
-static void *
-otel_RunLogsThread(void *pointer)
+static void
+otel_SendLogsToCollector(struct otelLogsExporter *exporter, CURL *http)
 {
-	struct otelLogsThread *t = pointer;
-
+	struct otelLogsBatch *batch;
+	OTEL_TYPE_EXPORT_LOGS(Request) request;
 	OTEL_TYPE_COMMON(InstrumentationScope) scopeData;
-	OTEL_TYPE_LOGS(ResourceLogs)  resourceLogsData;
-	OTEL_TYPE_LOGS(ResourceLogs) *resourceLogsList[1] = { &resourceLogsData };
-	OTEL_TYPE_LOGS(ScopeLogs)     scopeLogsData;
-	OTEL_TYPE_LOGS(ScopeLogs)    *scopeLogsList[1] = { &scopeLogsData };
+	ListCell *cell;
 
+	if (dlist_is_empty(&exporter->queue))
+		return;
+
+	OTEL_FUNC_EXPORT_LOGS(request__init)(&request);
 	OTEL_FUNC_COMMON(instrumentation_scope__init)(&scopeData);
-	OTEL_FUNC_LOGS(resource_logs__init)(&resourceLogsData);
-	OTEL_FUNC_LOGS(scope_logs__init)(&scopeLogsData);
 
 	/*
 	 * All log records come from the same instrumentation scope: this module.
-	 * The attributes are assigned according to v1.9.0 of the OpenTelemetry Specification.
 	 * - https://docs.opentelemetry.io/reference/specification/glossary/#instrumentation-scope
-	 * - https://docs.opentelemetry.io/reference/specification/schemas/overview/
 	 */
 	scopeData.name = PG_OTEL_LIBRARY;
 	scopeData.version = PG_OTEL_VERSION;
-	scopeLogsData.schema_url = "https://opentelemetry.io/schemas/1.9.0";
-	scopeLogsData.scope = &scopeData;
 
-	resourceLogsData.resource = &t->resource.resource;
-	resourceLogsData.scope_logs = scopeLogsList;
-	resourceLogsData.n_scope_logs = 1;
+	batch = dlist_head_element(struct otelLogsBatch, list_node,
+							   &exporter->queue);
 
-	for (;;)
+	request.n_resource_logs = batch->resourceLogs->length;
+	request.resource_logs = MemoryContextAlloc(batch->context,
+											   sizeof(*request.resource_logs) *
+											   request.n_resource_logs);
+
+	cell = list_head(batch->resourceLogs);
+	for (int i = 0; i < request.n_resource_logs; i++)
 	{
-		/*
-		 * Wait for the worker to indicate there are records to send.
-		 */
-		WaitLatch(&t->batchLatch, WL_LATCH_SET, -1, PG_WAIT_EXTENSION);
-		LWLockAcquire(t->lock, LW_EXCLUSIVE);
-		ResetLatch(&t->batchLatch);
-
-		/*
-		 * When there are records to send, flip the batches so the worker can
-		 * continue to read from the local IPC while this thread sends to the
-		 * remote collector.
-		 */
-		if (t->batchHold.length > 0)
-		{
-			struct otelLogsBatch temp = t->batchHold;
-			t->batchHold = t->batchSend;
-			t->batchSend = temp;
-		}
-
-		LWLockRelease(t->lock);
-
-		/*
-		 * When there are records to send, send them as a single request then
-		 * release their resources.
-		 */
-		if (t->batchSend.length > 0)
-		{
-			OTEL_TYPE_EXPORT_LOGS(Request) request;
-			OTEL_FUNC_EXPORT_LOGS(request__init)(&request);
-
-			request.resource_logs       = resourceLogsList;
-			request.n_resource_logs     = 1;
-			scopeLogsData.log_records   = t->batchSend.records;
-			scopeLogsData.n_log_records = t->batchSend.length;
-
-			otel_SendLogsToCollector(t, &request);
-			otel_ResetLogsBatch(&t->batchSend);
-		}
-
-		if (t->quit)
-			break;
+		request.resource_logs[i] = lfirst(cell);
+		request.resource_logs[i]->schema_url = PG_OTEL_SCHEMA;
+		request.resource_logs[i]->scope_logs[0]->schema_url = PG_OTEL_SCHEMA;
+		request.resource_logs[i]->scope_logs[0]->scope = &scopeData;
+#if PG_VERSION_NUM >= 130000
+		cell = lnext(batch->resourceLogs, cell);
+#else
+		cell = lnext(cell);
+#endif
 	}
 
-	return NULL;
+	otel_SendLogsRequestToCollector(batch->context, http, exporter, &request);
+
+	dlist_pop_head_node(&exporter->queue);
+	exporter->queueLength -= batch->length;
+
+	MemoryContextDelete(batch->context);
 }
 
 static void
-otel_InitLogsThread(struct otelLogsThread *t, LWLock *lock, int batchCapacity)
+otel_InitLogsExporter(struct otelLogsExporter *exporter,
+					  const struct otelConfiguration *config)
 {
-	t->lock = lock;
+	dlist_init(&exporter->queue);
+	exporter->endpoint = NULL;
+	exporter->queueLength = 0;
 
-	InitLatch(&t->batchLatch);
-	otel_InitLogsBatch(&t->batchHold, batchCapacity);
-	otel_InitLogsBatch(&t->batchSend, batchCapacity);
-	otel_InitResource(&t->resource);
-
-	t->http = curl_easy_init();
-	if (t->http == NULL)
-		ereport(FATAL, (errmsg("could not initialize curl for otel logs")));
-
-	t->endpoint = NULL;
-	t->insecure = false;
-	t->timeoutMS = 0;
+	otel_InitResource(&exporter->resource);
+	otel_LoadLogsConfig(exporter, config);
 }
 
 /*
  * Called by the background worker when PostgreSQL configuration changes.
  */
 static void
-otel_LoadLogsConfig(struct otelLogsThread *t, struct otelConfiguration *config)
+otel_LoadLogsConfig(struct otelLogsExporter *exporter,
+					const struct otelConfiguration *config)
 {
-	LWLockAcquire(t->lock, LW_EXCLUSIVE);
-
-	otel_LoadResource(config, &t->resource);
+	otel_LoadResource(config, &exporter->resource);
 
 	/*
 	 * Per-signal URLs MUST be used as-is without any modification. When there
@@ -467,49 +475,25 @@ otel_LoadLogsConfig(struct otelLogsThread *t, struct otelConfiguration *config)
 
 		appendStringInfoString(&str, "v1/logs");
 
-		if (t->endpoint)
-			pfree(t->endpoint);
-		t->endpoint = str.data;
+		if (exporter->endpoint)
+			pfree(exporter->endpoint);
+		exporter->endpoint = str.data;
 	}
 
 	{
 		Assert(config->otlpLogs.timeoutMS == 0); /* TODO: per-signal */
 
-		t->timeoutMS = config->otlp.timeoutMS;
+		exporter->timeoutMS = config->otlp.timeoutMS;
 	}
 
-	LWLockRelease(t->lock);
-}
+	/*
+	 * TODO: Accept settings for "Batch LogRecord Processor"
+	 * - https://docs.opentelemetry.io/reference/specification/sdk-environment-variables/
+	 *
+	 * TODO: Clamp both >= 1 for now.
+	 */
+	exporter->batchMax = 512;
+	exporter->queueMax = 2048;
 
-/*
- * Called by the background worker to start the exporter thread.
- */
-static void
-otel_StartLogsThread(struct otelLogsThread *t)
-{
-	if (pthread_create(&t->thread, NULL, otel_RunLogsThread, (void *)t) != 0)
-		ereport(FATAL, (errmsg("could not create otel logs thread")));
-}
-
-/*
- * Called by the background worker after it adds to the exporter batch.
- */
-static void
-otel_WakeLogsThread(struct otelLogsThread *t)
-{
-	LWLockAcquire(t->lock, LW_EXCLUSIVE);
-	SetLatch(&t->batchLatch);
-	LWLockRelease(t->lock);
-}
-
-/*
- * Called by the background worker after it sets t->quit.
- */
-static void
-otel_WaitLogsThread(struct otelLogsThread *t)
-{
-	pthread_join(t->thread, NULL);
-
-	if (t->http != NULL)
-		curl_easy_cleanup(t->http);
+	exporter->insecure = false;
 }


### PR DESCRIPTION
Each batch contains the data needed for a single request. When the queue of log records grows too long, further records are tallied as dropped in the youngest batch.

This also replaces threading with a one-second poll. A future commit will make that duration configurable.

Fixes #4