### PR TITLE
Capture and export during shutdown

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
             -o Dir::Etc::sourceparts='-' \
             -o APT::Get::List-Cleanup=0
 
-          sudo apt-get install postgresql-common
+          sudo apt-get install postgresql-common libipc-run-perl
           sudo tee -a /etc/postgresql-common/createcluster.conf <<< 'create_main_cluster = false'
 
           set -x
@@ -38,6 +38,12 @@ jobs:
           sudo apt-get install "postgresql-${PG_MAJOR}" "postgresql-server-dev-${PG_MAJOR}"
 
           echo >> $GITHUB_PATH "/usr/lib/postgresql/${PG_MAJOR}/bin"
+
+      - name: Install Collector
+        run: |
+          id=$(docker create ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:latest)
+          docker cp "${id}:/otelcol" - | tar -xC /usr/local/bin
+          docker rm "${id}"
 
       - uses: actions/checkout@v3
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,11 +24,7 @@ jobs:
           (. /etc/os-release && sudo tee /etc/apt/sources.list.d/pgdg.list <<< \
             "deb [signed-by=/usr/share/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME}-pgdg main ${PG_MAJOR}")
 
-          sudo apt-get update \
-            -o Dir::Etc::sourcelist='sources.list.d/pgdg.list' \
-            -o Dir::Etc::sourceparts='-' \
-            -o APT::Get::List-Cleanup=0
-
+          sudo apt-get update
           sudo apt-get install postgresql-common libipc-run-perl
           sudo tee -a /etc/postgresql-common/createcluster.conf <<< 'create_main_cluster = false'
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ OTEL_PROTO_FILES = $(patsubst opentelemetry-proto/%,%,\
 
 REGRESS = config
 REGRESS_OPTS = --temp-config='test/postgresql.conf'
+TAP_TESTS = yes
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/pg_otel.c
+++ b/pg_otel.c
@@ -105,6 +105,12 @@ otel_ProcExitHook(int code, Datum arg)
 	worker.pid = MyProcPid;
 	otel_CloseWrite(&worker.ipc);
 	otel_WorkerDrain(&worker, &config);
+
+	/*
+	 * Finish with libcurl. It was initialized during [_PG_init].
+	 * - https://curl.se/libcurl/c/libcurl.html#GLOBAL
+	 */
+	curl_global_cleanup();
 }
 
 /*
@@ -158,7 +164,6 @@ _PG_init(void)
 
 	/*
 	 * Initialize libcurl as soon as possible; not all versions are thread-safe.
-	 * TODO: Call curl_global_cleanup before postgres terminates?
 	 * - https://curl.se/libcurl/c/libcurl.html#GLOBAL
 	 */
 	if (curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK)

--- a/pg_otel_worker.c
+++ b/pg_otel_worker.c
@@ -70,6 +70,8 @@ otel_WorkerDrain(struct otelWorker *worker, struct otelConfiguration *config)
 		if (otel_WorkerReadIPC(&worker->ipc, &exporter, http))
 			break;
 	}
+
+	curl_easy_cleanup(http);
 }
 
 static void
@@ -118,4 +120,6 @@ otel_WorkerRun(struct otelWorker *worker, struct otelConfiguration *config)
 		if (worker->gotSIGTERM && idle)
 			break;
 	}
+
+	curl_easy_cleanup(http);
 }

--- a/t/001_lifecycle.pl
+++ b/t/001_lifecycle.pl
@@ -1,0 +1,62 @@
+
+use strict;
+use warnings;
+
+use IPC::Run ();
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+my $node = PostgreSQL::Test::Cluster->new('main');
+my $otlp_port = PostgreSQL::Test::Cluster::get_free_port();
+
+# Start the OpenTelemetry Collector
+my $otlp_file = $node->basedir() . '/otlp.ndjson';
+my $collector;
+eval
+{
+	{ open my $fh, '>', $otlp_file; close $fh; };
+	$collector = IPC::Run::start(
+	['otelcol', '--config', 'test/otel-collector.yaml',
+		'--set', "exporters.file.path=${otlp_file}",
+		'--set', "receivers.otlp.protocols.http.endpoint=localhost:${otlp_port}"],
+	'2>', $node->basedir() . '/otelcol.log');
+};
+if ($@)
+{
+	plan skip_all => 'otelcol (OpenTelemetry Collector) is needed to run this test';
+}
+
+# Start PostgreSQL with logs enabled
+$node->init();
+$node->append_conf('postgresql.conf', qq(
+shared_preload_libraries = pg_otel
+
+otel.export = logs
+otel.otlp_endpoint = http://localhost:${otlp_port}
+));
+$node->start();
+
+# Expect events from startup to be exported
+my $otlp_json = slurp_file($otlp_file);
+like($otlp_json, qr/
+	.+?"severityText":"LOG","body":\{"stringValue":"starting\ PostgreSQL
+	.+?"severityText":"LOG","body":\{"stringValue":"listening
+/sx, 'works for initial messages');
+
+# Stop PostgreSQL
+$node->stop();
+
+# Expect events from shutdown to be exported
+# - The "shutting down" message is emitted by the checkpointer process.
+# - The "database system is shut down" message is emitted by postmaster during
+#   an on_proc_exit hook. [miscinit.c]
+$otlp_json = slurp_file($otlp_file, length($otlp_json));
+like($otlp_json, qr/
+	.+?"severityText":"LOG","body":\{"stringValue":"shutting\ down"
+/sx, 'works for final messages');
+
+# Stop the OpenTelemetry Collector
+$collector->kill_kill();
+
+done_testing();


### PR DESCRIPTION
This exports the "shutting down" message from the checkpointer, but not the very last "database system is shut down" message from postmaster.